### PR TITLE
allow customising which paste register to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,13 @@ To change default mapping to open the peekup window simply specify the right han
 let g:peekup_open = '<leader>"'
 ```
 
+To change the default register the selected paste goes into (default: `*`):
+
+```
+" put selection into " register instead:
+lua require('nvim-peekup.config').paste_reg = '"'
+```
+
 ## Help tags
 Access the documentation with `:h nvim-peekup`.
 

--- a/doc/peekup.txt
+++ b/doc/peekup.txt
@@ -108,5 +108,9 @@ and sorted by character.
 
 	To change default mapping to open the peekup window use
 	`let g:peekup_open = '<leader>"'`
+
+	To change the default register the selected paste goes into (default: `*`):
+	" put selection into " register instead:
+	lua require('nvim-peekup.config').paste_reg = '"'
 vim:ft=help:et:ts=2:sw=2:sts=2:norl
 

--- a/lua/nvim-peekup/config.lua
+++ b/lua/nvim-peekup/config.lua
@@ -12,6 +12,8 @@ local on_keystroke = {
    padding = 3
 }
 
+local paste_reg = '*'
+
 local reg_chars = {}
 local chars = 'abcdefghijklmnopqrstuvwxyz0123456789*+-%'
 chars:gsub(".",function(c) table.insert(reg_chars,c) end)
@@ -20,4 +22,5 @@ return {
    geometry = geometry,
    on_keystroke = on_keystroke,
    reg_chars = reg_chars,
+   paste_reg = paste_reg,
 }

--- a/lua/nvim-peekup/peekup.lua
+++ b/lua/nvim-peekup/peekup.lua
@@ -98,7 +98,7 @@ local function on_keystroke(key)
 	  vim.cmd('redraw')
 	  vim.cmd('sleep '..config.on_keystroke.delay)
 	  vim.cmd('execute "normal! \\<Esc>^"')
-	  vim.cmd('let @*=@'..key)
+	  vim.cmd('let @'..config.paste_reg..'=@'..key)
 	  if config.on_keystroke.autoclose then
 		 vim.cmd('redraw')
 		 vim.cmd('sleep '..config.on_keystroke.delay)


### PR DESCRIPTION
This likely needs a little TLC on the documentation side; the idea is to make it _configurable_ which register is the selected register's contents going to be pasted into.

It's currently hard-coded to the `*` register and while it's easy to modify the source to change the register to be whatever the user wants, making that a _configuration setting_ means one doesn't need to keep a forked version lying around and can just change their own configuration instead.