### PR TITLE
optionally automatically paste after having picked register

### DIFF
--- a/doc/peekup.txt
+++ b/doc/peekup.txt
@@ -70,6 +70,17 @@ and sorted by character.
 	To change key mapping to open the peekup window specify use the option
 	`let g:peekup_open = ...`
 
+  To automatically paste before or after having selected a register, you can
+  pass an argument to peekup_open containing the paste command (`p` or `P`) to
+  use, i.e.:
+
+  `:lua require('nvim-peekup').peekup_open("P")<CR>`
+
+  or:
+
+  `:nnoremap <Leader>P :lua require('nvim-peekup').peekup_open("P")<CR>`
+  `:nnoremap <Leader>p :lua require('nvim-peekup').peekup_open("p")<CR>`
+
 ------------------------------------------------------------------------------
     2b. USAGE         *peekup-usage*
 

--- a/lua/nvim-peekup/init.lua
+++ b/lua/nvim-peekup/init.lua
@@ -5,7 +5,7 @@ sets the corresponding buffer options and commands on keystroke ]]
 local peekup = require("nvim-peekup.peekup")
 local config = require("nvim-peekup.config")
 
-local function set_peekup_opts(buf)
+local function set_peekup_opts(buf, paste_where)
    vim.api.nvim_buf_set_option(buf, 'filetype', 'peek')
    vim.api.nvim_buf_set_option(buf, 'bufhidden', 'wipe')
    vim.api.nvim_buf_set_option(buf, 'modifiable', false)
@@ -34,20 +34,24 @@ local function set_peekup_opts(buf)
 
    -- setting peekup keymaps
    for _, v in ipairs(config.reg_chars) do
-	  vim.api.nvim_buf_set_keymap(buf, 'n', v, ':lua require"nvim-peekup.peekup".on_keystroke(\"'..v..'\")<cr>', { nowait = true, noremap = true, silent = true })
+	  vim.api.nvim_buf_set_keymap(buf, 'n', v, ':lua require"nvim-peekup.peekup".on_keystroke(\"'..v..'\",\"'..paste_where..'\")<cr>', { nowait = true, noremap = true, silent = true })
    end
    vim.api.nvim_buf_set_keymap(buf, 'n', '<Down>', ']`', { nowait = true, noremap = true, silent = true })
    vim.api.nvim_buf_set_keymap(buf, 'n', '<Up>', '[`', { nowait = true, noremap = true, silent = true })
 end
 
-local function peekup_open()
+local function peekup_open(paste_where)
    local peekup_buf = peekup.floating_window(config.geometry)
    local lines = peekup.reg2t()
    table.insert(lines, 1, peekup.centre_string(config.geometry.title))
    table.insert(lines, 2, '')
 
+   if paste_where == nil then
+      paste_where = ''
+   end
+
    vim.api.nvim_buf_set_lines(peekup_buf, 0, -1, true, lines)
-   set_peekup_opts(peekup_buf)
+   set_peekup_opts(peekup_buf, paste_where)
 end
 
 return {

--- a/lua/nvim-peekup/init.lua
+++ b/lua/nvim-peekup/init.lua
@@ -42,7 +42,7 @@ end
 
 local function peekup_open(paste_where)
    local peekup_buf = peekup.floating_window(config.geometry)
-   local lines = peekup.reg2t()
+   local lines = peekup.reg2t(paste_where)
    table.insert(lines, 1, peekup.centre_string(config.geometry.title))
    table.insert(lines, 2, '')
 

--- a/lua/nvim-peekup/peekup.lua
+++ b/lua/nvim-peekup/peekup.lua
@@ -9,10 +9,16 @@ local function get_reg(char)
 	return vim.fn.getreg(char):gsub("[\n\r]", "^J")
 end
 
-local function reg2t()
+local function reg2t(paste_where)
    -- parses the registers into a lua table
    local numerical_reg = {}
-   table.insert(numerical_reg, 'Numerical -> press number to copy')
+   local action = 'to copy'
+   if paste_where == 'p' then
+       action = 'to paste after the cursor'
+   elseif paste_where == 'P' then
+       action = 'to paste before the cursor'
+   end
+   table.insert(numerical_reg, 'Numerical -> press number '..action)
    for _, v in pairs(config.reg_chars) do
 	  if string.match(v, "%d") and get_reg(v) ~='' then
 		 table.insert(numerical_reg, v..':'..string.rep(' ', config.on_keystroke.padding)..get_reg(v))
@@ -21,7 +27,7 @@ local function reg2t()
    table.insert(numerical_reg, '')
 
    local alpha_reg = {}
-   table.insert(alpha_reg, 'Literal -> press letter to copy')
+   table.insert(alpha_reg, 'Literal -> press letter '..action)
    for _, v in pairs(config.reg_chars) do
 	  if string.match(v, "%a") and get_reg(v) ~='' then
 		 table.insert(alpha_reg, v..':'..string.rep(' ', config.on_keystroke.padding)..get_reg(v))
@@ -30,7 +36,7 @@ local function reg2t()
    table.insert(alpha_reg, '')
 
    local special_reg = {}
-   table.insert(alpha_reg, 'Special -> press character to copy')
+   table.insert(alpha_reg, 'Special -> press character '..action)
    for _, v in pairs(config.reg_chars) do
 	  if string.match(v, "%p") and get_reg(v) ~='' then
 		 table.insert(special_reg, v..':'..string.rep(' ', config.on_keystroke.padding)..get_reg(v))

--- a/lua/nvim-peekup/peekup.lua
+++ b/lua/nvim-peekup/peekup.lua
@@ -88,7 +88,7 @@ local function floating_window(geometry)
    return buf
 end
 
-local function on_keystroke(key)
+local function on_keystroke(key, paste_where)
    -- defines the action to be undertaken upon keystroke in the peekup window
    local search_key = key=='*' and '\\'..key or key
    if vim.api.nvim_exec('echo search("^'..search_key.. ':") > 0', true) ~= '0' then
@@ -108,6 +108,9 @@ local function on_keystroke(key)
 		 end
 		 vim.cmd(':q')
 	  end
+      if paste_where then
+         vim.cmd('execute "normal! \\"'..key..paste_where..'"')
+      end
    else
 	  vim.cmd('echo "register '..key..' not available"')
    end


### PR DESCRIPTION
... in a smaller patch and with simpler logic than originally
discussed/proposed on:

    https://github.com/gennaro-tedesco/nvim-peekup/issues/9

As to how to use this:

    nnoremap <Plug>PeekupOpenThenPasteBefore :lua require('nvim-peekup').peekup_open("P")<CR>
    nnoremap <Plug>PeekupOpenThenPasteAfter  :lua require('nvim-peekup').peekup_open("p")<CR>
    nnoremap <Leader>P <Plug>PeekupOpenThenPasteBefore
    nnoremap <Leader>p <Plug>PeekupOpenThenPasteAfter

... or possibly more succinctly:

    nnoremap <Leader>P :lua require('nvim-peekup').peekup_open("P")<CR>
    nnoremap <Leader>p :lua require('nvim-peekup').peekup_open("p")<CR>

I'm not sure either the <Plug> mappings or a set of default mappings
ought to go in the default configuration.