### PR TITLE
ignore + and * register unless has("clipboard")

### DIFF
--- a/lua/nvim-peekup/config.lua
+++ b/lua/nvim-peekup/config.lua
@@ -1,5 +1,8 @@
 local reg_chars = {}
-local chars = 'abcdefghijklmnopqrstuvwxyz0123456789*+-%'
+local chars = 'abcdefghijklmnopqrstuvwxyz0123456789-%'
+if vim.fn.has("clipboard") == 1 then
+   chars = 'abcdefghijklmnopqrstuvwxyz0123456789*+-%'
+end
 chars:gsub(".",function(c) table.insert(reg_chars,c) end)
 
 local geometry = {


### PR DESCRIPTION
... as otherwise Vim complains (multiple times) about the clipboard when
opening the pop-up window, if no clipboard is available.

So, by default show all registers _but_ the ones related to the
clipboard, and show them all otherwise.

Unsure if this is "echo has clipboard" is the best way to go about it,
honestly - but it worked for me.