### PR TITLE
only sleep IFF config.on_keystroke.delay is not empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,13 @@ lua require('nvim-peekup.config').on_keystroke["delay"] = '300ms'
 lua require('nvim-peekup.config').on_keystroke["autoclose"] = false
 lua require('nvim-peekup.config').on_keystroke["paste_reg"] = '"'
 ```
-`delay` expresses the delay before the peekup window closes automatically, after selecting the register. Obviously, `autoclose` set to false prevents such behaviour (and the user must close the window manually). The selected paste goes into the default register `*`: change accordingly if needed.
+`delay` expresses the delay before the peekup window closes automatically, after selecting the register. Obviously, `autoclose` set to false prevents such behaviour (and the user must close the window manually).
+`delay` can be set to the empty string to not delay at all, i.e.:
+```
+lua require('nvim-peekup.config').on_keystroke["delay"] = ''
+```
+
+The selected paste goes into the default register `*`: change accordingly if needed.
 
 To change default mapping to open the peekup window simply specify the right hand side of
 ```

--- a/doc/peekup.txt
+++ b/doc/peekup.txt
@@ -105,7 +105,10 @@ and sorted by character.
 	`delay` expresses the delay before the peekup window closes automatically,
 	after selecting the register. Obviously, `autoclose` set to false prevents
 	such behaviour (and the user must close the window manually).
-
+	`delay` can be set to the empty string to not delay at all, i.e.:
+>
+	lua require('nvim-peekup.config').on_keystroke["delay"] = ''
+<
 	To change default mapping to open the peekup window use
 	`let g:peekup_open = '<leader>"'`
 

--- a/lua/nvim-peekup/peekup.lua
+++ b/lua/nvim-peekup/peekup.lua
@@ -96,12 +96,16 @@ local function on_keystroke(key)
 	  vim.cmd(':noh')
 	  vim.cmd('execute "normal! ^f:'..config.on_keystroke.padding+1 ..'lvg_"')
 	  vim.cmd('redraw')
-	  vim.cmd('sleep '..config.on_keystroke.delay)
+	  if config.on_keystroke.delay ~= "" then
+	     vim.cmd('sleep '..config.on_keystroke.delay)
+	  end
 	  vim.cmd('execute "normal! \\<Esc>^"')
 	  vim.cmd('let @'..config.on_keystroke.paste_reg..'=@'..key)
 	  if config.on_keystroke.autoclose then
 		 vim.cmd('redraw')
-		 vim.cmd('sleep '..config.on_keystroke.delay)
+		 if config.on_keystroke.delay ~= "" then
+			 vim.cmd('sleep '..config.on_keystroke.delay)
+		 end
 		 vim.cmd(':q')
 	  end
    else


### PR DESCRIPTION
... thus allowing one to set:

    lua require('nvim-peekup.config').on_keystroke["delay"] = ''

... and get no delay/sleep whatsoever.