### PR TITLE
Fix registers

### DIFF
--- a/lua/nvim-peekup/config.lua
+++ b/lua/nvim-peekup/config.lua
@@ -1,7 +1,7 @@
 local reg_chars = {}
-local chars = 'abcdefghijklmnopqrstuvwxyz0123456789-%'
+local chars = 'abcdefghijklmnopqrstuvwxyz0123456789-.%/'
 if vim.fn.has("clipboard") == 1 then
-   chars = 'abcdefghijklmnopqrstuvwxyz0123456789*+-%'
+   chars = 'abcdefghijklmnopqrstuvwxyz0123456789*+-.%/'
 end
 chars:gsub(".",function(c) table.insert(reg_chars,c) end)
 

--- a/lua/nvim-peekup/init.lua
+++ b/lua/nvim-peekup/init.lua
@@ -41,8 +41,8 @@ local function set_peekup_opts(buf, paste_where)
 end
 
 local function peekup_open(paste_where)
-   local peekup_buf = peekup.floating_window(config.geometry)
    local lines = peekup.reg2t(paste_where)
+   local peekup_buf = peekup.floating_window(config.geometry)
    table.insert(lines, 1, peekup.centre_string(config.geometry.title))
    table.insert(lines, 2, '')
 

--- a/syntax/peek.vim
+++ b/syntax/peek.vim
@@ -11,8 +11,8 @@ endfor
 unlet s:section
 
 execute 'syntax match RegTitle /^\s*' . luaeval("require('nvim-peekup.config').geometry[\"title\"]") . '/'
-syntax match RegName /^[0-9A-Za-z*+%-]/ contained
-syntax match RegNamePrefix /^[0-9A-Za-z*+%-]:/ contains=RegName
+syntax match RegName /^[\/0-9A-Za-z*+.%-]/ contained
+syntax match RegNamePrefix /^[\/0-9A-Za-z*+.%-]:/ contains=RegName
 
 highlight default link RegTitle Title
 highlight default link RegNamePrefix Label


### PR DESCRIPTION
- add missing dot and slash registers - both as supported register names and as highlighted syntax tokens in the pop-up
- fetch register contents *before* opening the pop-up window, so the contents of the `%` register are properly populated to the file name of the buffer the pop-up was launched _from_